### PR TITLE
Fix badge url and set line length 100

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/khink/Communicator-Web_version-.svg?branch=master)](https://travis-ci.org/khink/Communicator-Web_version-)
+[![Build Status](https://travis-ci.org/AndriesSHP/Communicator-Web_version-.svg?branch=master)](https://travis-ci.org/AndriesSHP/Communicator-Web_version-)
 
 # Communicator-Web_version-
 A web version of the Gellish Communicator App using RemiGUI

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,5 @@
 [flake8]
+max-line-length = 100
 ignore = D100,D101,D102,D202,D203,D205,D208,D210,D300,D400
 exclude =
     # No need to traverse our git directory


### PR DESCRIPTION
- make badge point to the AndriesSHP repo's Travis job
- allow up to 100 chars in line