### PR TITLE
Flake8, the final fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: python
 python:
   - "3.6"
 script:
-  - make test
+  - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 python:
   - "3.6"
+install:
+  - "pip install pytest-flake8"
 script:
   - pytest

--- a/Web-Communicator/Display_views.py
+++ b/Web-Communicator/Display_views.py
@@ -3314,10 +3314,11 @@ class Display_views():
                 if body is True:
                     # Set background color
                     # depending on either header, value present or 'unknown'
-                    if (column_nr == 1 and (field_value in self.comp_head
-                                            or field_value in self.occ_head
-                                            or field_value in self.info_head)) \
-                            or (column_nr == 2 and (field_value in self.part_occ_head)):
+                    if (column_nr == 1 and (
+                            field_value in self.comp_head or
+                            field_value in self.occ_head or
+                            field_value in self.info_head)) \
+                            or column_nr == 2 and field_value in self.part_occ_head:
                         # Header line detected; set background color accordingly
                         head = True
                         back = '#dfb'

--- a/Web-Communicator/Display_views.py
+++ b/Web-Communicator/Display_views.py
@@ -1198,15 +1198,15 @@ class Display_views():
                 # Find expression with poss_of_aspect relations about the object
                 # (or its supertype)
                 if expr[lh_uid_col] == obj_i.uid \
-                        and (expr[rel_type_uid_col] in self.gel_net.subConcPossAspUIDs
-                             and not expr[rel_type_uid_col] in self.gel_net.conc_playing_uids):
+                        and expr[rel_type_uid_col] in self.gel_net.subConcPossAspUIDs \
+                        and not expr[rel_type_uid_col] in self.gel_net.conc_playing_uids:
                     aspect_uid = expr[rh_uid_col]
                     aspect_name = expr[rh_name_col]
                     role_uid = expr[rh_role_uid_col]
                     # role_name = expr[rh_role_name_col]
                 elif expr[rh_uid_col] == obj_i.uid \
-                        and (expr[rel_type_uid_col] in self.gel_net.subConcPossAspUIDs
-                             and not expr[rel_type_uid_col] in self.gel_net.conc_playing_uids):
+                        and expr[rel_type_uid_col] in self.gel_net.subConcPossAspUIDs \
+                        and not expr[rel_type_uid_col] in self.gel_net.conc_playing_uids:
                     aspect_uid = expr[lh_uid_col]
                     aspect_name = expr[lh_name_col]
                     role_uid = expr[lh_role_uid_col]
@@ -1831,8 +1831,8 @@ class Display_views():
         # (involver role players)
         for rel_obj in obj.relations:
             expr = rel_obj.expression
-            if (expr[rh_uid_col] == obj.uid
-                    and expr[rel_type_uid_col] in self.gel_net.subInvolvUIDs):
+            if expr[rh_uid_col] == obj.uid \
+                    and expr[rel_type_uid_col] in self.gel_net.subInvolvUIDs:
                 occ_uid = expr[lh_uid_col]
                 # occ_name = expr[lh_name_col]
             elif expr[lh_uid_col] == obj.uid \
@@ -1903,14 +1903,14 @@ class Display_views():
                 # or any of its subtypes relations in occ
                 # excluding the object in focus (obj)
                 if expr_occ[rh_uid_col] != obj.uid \
-                        and (expr_occ[lh_uid_col] == occ.uid
-                             and expr_occ[rel_type_uid_col] in self.gel_net.subInvolvUIDs):
+                        and expr_occ[lh_uid_col] == occ.uid \
+                        and expr_occ[rel_type_uid_col] in self.gel_net.subInvolvUIDs:
                     involved_uid = expr_occ[rh_uid_col]
                     # involved_name = expr_occ[rh_name_col]
                     inv_role_name = expr_occ[rh_role_name_col]
                 elif expr_occ[lh_uid_col] != obj.uid \
-                        and (expr_occ[rh_uid_col] == occ.uid
-                             and expr_occ[rel_type_uid_col] in self.gel_net.subInvolvUIDs):
+                        and expr_occ[rh_uid_col] == occ.uid \
+                        and expr_occ[rel_type_uid_col] in self.gel_net.subInvolvUIDs:
                     involved_uid = expr_occ[lh_uid_col]
                     # involved_name = expr_occ[lh_name_col]
                     inv_role_name = expr_occ[lh_role_name_col]

--- a/Web-Communicator/Display_views.py
+++ b/Web-Communicator/Display_views.py
@@ -2609,8 +2609,7 @@ class Display_views():
                 indiv_parents.append(indiv_line[1])
 
     def Define_expressions_sheet(self):
-        ''' Define expressions view sheet for display of expr_table in Notebook tab
-        '''
+        """Define expressions view sheet for display of expr_table in Notebook tab"""
         self.expr_frame = Frame(self.views_noteb)
         self.expr_frame.grid(column=0, row=0, sticky=NSEW, rowspan=4)
         self.expr_frame.columnconfigure(0, weight=1)
@@ -3642,8 +3641,7 @@ class Display_views():
             self.Determine_category_of_object_view(chosen_object_uid, tree_values)
 
     def Determine_network_tree_values(self):
-        ''' Determine the values on a selected focus row in a network treeview
-        '''
+        """Determine the values on a selected focus row in a network treeview"""
         cur_item = self.network_tree.focus()
         tree_values = []
         if cur_item != '':
@@ -3656,8 +3654,7 @@ class Display_views():
         return tree_values
 
     def Determine_category_of_object_view(self, chosen_object_uid, tree_values):
-        ''' Determine kind of chosen object and as a consequence models and views
-        '''
+        """Determine kind of chosen object and as a consequence models and views"""
         description_text = ['description', 'beschrijving']
         obj_descr_title = ['Information about ', 'Informatie over ']
 

--- a/Web-Communicator/GellishDict.py
+++ b/Web-Communicator/GellishDict.py
@@ -98,29 +98,29 @@ if __name__ == "__main__":
     # print all items that have "pump" as the third field in the key:
     candidates = d.filter_on_key("pump", 'csi')
     for candidate in candidates:
-        print ("case sensitive identical (pump): ", candidate)
+        print("case sensitive identical (pump): ", candidate)
 
     # print all items that contain "Pu" at the front end of the third field of the key:
     candidates = d.filter_on_key("Pu", 'csfi')
     for candidate in candidates:
-        print ("case sensitive front end identical (Pu): ", candidate)
+        print("case sensitive front end identical (Pu): ", candidate)
 
     # print all items that contain "ump" as a string somewhere in the third field of the key:
     candidates = d.filter_on_key("ump", 'cspi')
     for candidate in candidates:
-        print ("case sensitive partially identical (ump): ", candidate)
+        print("case sensitive partially identical (ump): ", candidate)
 
     # print all items that have "pump" as the third field in the key:
     candidates = d.filter_on_key("pump", 'cii')
     for candidate in candidates:
-        print ("case insensitive identical (pump): ", candidate)
+        print("case insensitive identical (pump): ", candidate)
 
     # print all items that contain "pu" at the front end of the third field of the key:
     candidates = d.filter_on_key("pu", 'cifi')
     for candidate in candidates:
-        print ("case insensitive front end identical (pu): ", candidate)
+        print("case insensitive front end identical (pu): ", candidate)
 
     # print all items that contain "i" as a string somewhere in the third field of the key:
     candidates = d.filter_on_key("i", 'cipi')
     for candidate in candidates:
-        print ("case insensitive partially identical (i): ", candidate)
+        print("case insensitive partially identical (i): ", candidate)

--- a/Web-Communicator/Gellish_file.py
+++ b/Web-Communicator/Gellish_file.py
@@ -451,8 +451,8 @@ class Gellish_file:
                 # Debug print('Col_ids',lang_name_col_id)
                 for col_id in lang_name_col_id:
                     # Only for rows with a specialization and alias relation
-                    if (db_row[rel_type_uid_col] in self.gel_net.specialRelUIDs
-                            or db_row[rel_type_uid_col] in self.gel_net.alias_uids):
+                    if db_row[rel_type_uid_col] in self.gel_net.specialRelUIDs \
+                            or db_row[rel_type_uid_col] in self.gel_net.alias_uids:
                         # Check whether column value (name of object) is not blank,
                         # then include name_in_context in the dictionary (if not yet present)
                         if in_row[lang_name_col_id[col_id]] != '':

--- a/Web-Communicator/Gellish_file.py
+++ b/Web-Communicator/Gellish_file.py
@@ -30,9 +30,9 @@ class Gellish_file:
     """
 
     def __init__(self, path_and_name, gel_net):
-        ''' Initialize a file that is read from a given location (path)
+        """ Initialize a file that is read from a given location (path)
             The file_name is without path or directory, but with file extension.
-        '''
+        """
         self.path_and_name = path_and_name
         self.gel_net = gel_net
         self.expressions = []
@@ -130,9 +130,9 @@ class Gellish_file:
             self.Import_expressions_from_Gellish_file(f, reader)
 
     def Interpret_non_gellish_JSON_file(self):
-        ''' Read a non-Gellish JSON file and convert it into a Gellish file
+        """ Read a non-Gellish JSON file and convert it into a Gellish file
             Guided by a mapping table
-        '''
+        """
         # Debug print('JSON file: {}'.format(self.json_list))
 
         quantification = [('5737', 'has by definition on scale a value equal to', '6066'),
@@ -286,10 +286,10 @@ class Gellish_file:
                          lang_name, serialization)
 
     def Import_expressions_from_Gellish_file(self, f, reader):
-        ''' Read the expressions from the current file in Gellish expression format
+        """ Read the expressions from the current file in Gellish expression format
             verify its quality
             and add its content to the semantic network
-        '''
+        """
 
         # Initialize expressions table
         self.expressions = []
@@ -523,7 +523,7 @@ class Gellish_file:
             # query.Interpret_query_spec()
 
     def Interpret_the_first_header_line(self):
-        ''' Interpret the (first) header line of a file with Gellish expressions.'''
+        """ Interpret the (first) header line of a file with Gellish expressions."""
 
         # Determine the file type (header[5]) and verify whether base ontology is first provided
         self.base_ontology = False
@@ -636,9 +636,9 @@ class Gellish_file:
                      self.upper_idea_range_uid))
 
     def Determine_highest_uids_in_ranges(self, reader, source_ids, loc_default_row):
-        ''' Determine what the highest uids are within the given ranges
+        """ Determine what the highest uids are within the given ranges
             for the lh and rh objects and for the ideas.
-        '''
+        """
         # Start with the lower value of the ranges
         self.highest_obj_uid = self.lower_obj_range_uid
         self.highest_idea_uid = self.lower_idea_range_uid
@@ -675,7 +675,7 @@ class Gellish_file:
         self.gel_net.new_idea_uid = self.highest_idea_uid + 1
 
     def Clean_whole_number(self, number):
-        ''' Ensure that a whole number is coded as an integer '''
+        """ Ensure that a whole number is coded as an integer """
         integer = True
         dots_removed = number.replace('.', '')
         commas_removed = dots_removed.replace(',', '')
@@ -688,11 +688,11 @@ class Gellish_file:
         return integer, uid
 
     def Rearrange_input_row(self, in_row, source_ids, loc_default_row):
-        ''' Rearrange values in in_row into db_row
+        """ Rearrange values in in_row into db_row
             conform the destination column ids specified in source_id_dict.
             Missing values are loaded with local default values,
             possibly from an in_row with default values.
-        '''
+        """
         # Load default values in row
         db_row = loc_default_row[:]
         # Put input fields from in_row in destination fields in db_row
@@ -723,12 +723,12 @@ class Gellish_file:
         return db_row
 
     def Verify_row(self, db_row):
-        ''' Verify values in db_row and amend where applicable,
+        """ Verify values in db_row and amend where applicable,
             before loading in semantic network.
             Per rel_type and kind first role and kind of second role
             add/verify kind of role players.
             Collect rows in expressions table.
-        '''
+        """
         correct = True
         # Collect used languages that denote language of left hand objects
         # Verify consistency of language names.

--- a/Web-Communicator/Query.py
+++ b/Web-Communicator/Query.py
@@ -1281,6 +1281,7 @@ class Query:
 # Transform and search for satisfaction in expressions table
 # === To be written ===
 
+    # TODO argument names should be lower case
     def TransitiveMatchChain(self, baseUID, relUIDSubs, targetUID, phraseTypeUIDQ):
         """ Search whether a targetUID is related to a baseUID in a chain of relations of type relUID.
             This results in a tree of branches (matchTreeUIDs of pairs of 'from-to' UIDs),
@@ -1300,6 +1301,7 @@ class Query:
                     previousUID = branch[0]
         return chain
 
+    # TODO argument names should be lower case
     def TransitiveMatch(self, baseUID, relUIDSubs, targetUID, phraseTypeUIDQ):
         """ Search recursively whether a targetUID is related to a baseUID
             in a chain of relations of type relUID.

--- a/Web-Communicator/Query.py
+++ b/Web-Communicator/Query.py
@@ -488,10 +488,10 @@ class Query:
         int_q_lh_uid, lh_integer = Convert_numeric_to_integer(self.q_lh_uid)
         int_q_rh_uid, rh_integer = Convert_numeric_to_integer(self.q_rh_uid)
         if self.rolePlayersQTypes == 'individuals' \
-                and (((lh_integer is False or int_q_lh_uid >= 100)
-                      and self.q_lh_category in list_of_categories)
-                     or ((rh_integer is False or int_q_rh_uid >= 100)
-                         and self.q_rh_category in list_of_categories)):
+                and (((lh_integer is False or int_q_lh_uid >= 100) and
+                     self.q_lh_category in list_of_categories) or
+                     ((rh_integer is False or int_q_rh_uid >= 100) and
+                     self.q_rh_category in list_of_categories)):
             print('Warning: Relation type <{}> relates individual things, '
                   'but one or both related things are kinds of things. Try again.'.
                   format(self.q_rel_name, self.q_lh_uid, self.q_lh_category,
@@ -499,12 +499,12 @@ class Query:
 
         # If relation type specifies a relation between kinds and the lh_object is known
         # then lh_object shall be a kind or kind of occurrence; idem for rh_object
-        elif (self.rolePlayersQTypes == 'hierOfKinds'
-              or self.rolePlayersQTypes == 'thingsOfKinds') \
-                and (((lh_integer is False or int_q_lh_uid >= 100)
-                      and self.q_lh_category not in list_of_categories)
-                     or ((rh_integer is False or int_q_rh_uid >= 100)
-                         and self.q_rh_category not in list_of_categories)):
+        elif (self.rolePlayersQTypes == 'hierOfKinds' or
+                self.rolePlayersQTypes == 'thingsOfKinds') and \
+                (((lh_integer is False or int_q_lh_uid >= 100) and
+                 self.q_lh_category not in list_of_categories) or
+                 ((rh_integer is False or int_q_rh_uid >= 100) and
+                    self.q_rh_category not in list_of_categories)):
             print('Warning: Relation type <{}> relates kinds of things, '
                   'but left {} ({}) or right {} ({}) related things are not kinds. '
                   'Try again.'.

--- a/Web-Communicator/Query.py
+++ b/Web-Communicator/Query.py
@@ -58,8 +58,8 @@ class Query:
         self.branches = []
 
     def Specify_query_via_command_line(self):
-        ''' Specify and interpret a query (q) about things in a semantic network.
-            Search for terms in the dictionary'''
+        """ Specify and interpret a query (q) about things in a semantic network.
+            Search for terms in the dictionary"""
 
         # Search in the dictionary (using a filter function), which returns values if
         # 0) search_string is equal to the third position of the first(key) field of an item:
@@ -87,12 +87,12 @@ class Query:
                 search_string = 'd'  # input("\nDisplay results (d): ")
 
     def Interpret_query_line(self, search_string):
-        '''A query line via a command line consists either of a single term string
+        """A query line via a command line consists either of a single term string
            or an expression, being lh_string < rel_string > rh_string = uom_string,
            in which < and > mark the beging and end of a relation type phrase.
            Resulting in a list called 'interpreted':
            [lh_uid,lh_name,rel_uid,rel_name,rh_uid,rh_name,uom_uid,uom_name]
-        '''
+        """
         string_commonalities = ['csi', 'cspi', 'csfi', 'cii', 'cipi', 'cifi']
 
         com = input("\nEnter string commonality (csi, cspi, csfi, cii, cipi, cifi): ")
@@ -190,12 +190,12 @@ class Query:
         return known_strings, interpreted  # list of Booleans, list
 
     def Formulate_query_spec_from_individual(self, selected_kind):
-        ''' Determine from a selected individual (to be modified object)
+        """ Determine from a selected individual (to be modified object)
             a query_spec that searches for
             subtypes of its kind (selected_kind)
             that satisfy the aspects of the individual object.
             Thus using the aspects of the individual as criteria for selection of options.
-        '''
+        """
         shall_have_as_aspect_phrase = ['shall have as aspect a',
                                        'moet als aspect hebben een']
         shall_be_phrase = ['shall be', 'moet als kwalitatief aspect hebben']
@@ -350,11 +350,11 @@ class Query:
             self.query_spec.append(query_expr)
 
     def Interpret_query_spec(self):
-        ''' Interpret a query_spec, consisting of one or more lines
+        """ Interpret a query_spec, consisting of one or more lines
             and if a single object is requested, then build product model and view
             or when possibly multiple objects are resulting, then execute the query
             and build the various product models and views.
-        '''
+        """
         self.obj_list[:] = []
         # Debug print('Query_spec:', self.query_spec)
         # If the query interpretation found a single known object
@@ -401,9 +401,9 @@ class Query:
             self.Execute_query()
 
     def Create_query_file(self):
-        ''' Create a file in Gellish Expression format
+        """ Create a file in Gellish Expression format
             on the basis of self.query_spec
-        '''
+        """
         # Debug print('Query_spec example:', self.query_spec)
         # Query_spec example:
         # [['251691', 'three core cable', '4956', 'shall have as aspect a',
@@ -852,10 +852,10 @@ class Query:
             self.Other_views()
 
     def Record_and_verify_candidate_object(self, expr):
-        ''' Identify candidate object and add object to list of candidates,
+        """ Identify candidate object and add object to list of candidates,
             if not yet present
             then verify additional conditions, if present
-        '''
+        """
         candid_uid = expr[lh_uid_col]
         if candid_uid not in self.candid_uid_dict:
             candid = self.gel_net.uid_dict[candid_uid]
@@ -876,10 +876,10 @@ class Query:
                 self.Verify_conditions(candid, expr)
 
     def Find_candidates(self, rhq):
-        ''' Search for relations with object rhq
+        """ Search for relations with object rhq
             that comply with the kind of relation in the query
             and collect the relations in self.candid_expressions
-        '''
+        """
         for obj_rel in rhq.relations:
             expr = obj_rel.expression
             # If relation of q_rh_obj is equal to self.q_rel_uid or one of its subtypes
@@ -1019,12 +1019,12 @@ class Query:
             self.query_spec.append(condition[:])
 
     def Verify_conditions(self, candid_obj, candidate_expr):
-        ''' Conditions found thus
+        """ Conditions found thus
             verify whether the candidate object identified by self.candid_expressions
             satisfies the entered conditions, if any,
             and store the results in the self.answer_expressions
             with the same column definitions as the expressions.
-        '''
+        """
         cond_satisfied = True
         candid_expr = candidate_expr
         # Conditions found thus check candidate expressions on conditions

--- a/Web-Communicator/QueryViews.py
+++ b/Web-Communicator/QueryViews.py
@@ -1046,6 +1046,7 @@ class Query_view():
                         # Find conceptual quantification (1791) value (on a scale)
                         # Find conceptual compliance criterion/qualif (4902)
                         # or def qualification
+                        # TODO: rewrite overly complex if-and-or statement
                         if role_uid == expr2[lh_uid_col] \
                                 and (expr2[lh_role_uid_col] in self.gel_net.concComplUIDs or
                                      expr2[rel_type_uid_col] in self.gel_net.concQuantUIDs or

--- a/Web-Communicator/QueryViews.py
+++ b/Web-Communicator/QueryViews.py
@@ -1047,9 +1047,9 @@ class Query_view():
                         # Find conceptual compliance criterion/qualif (4902)
                         # or def qualification
                         if role_uid == expr2[lh_uid_col] \
-                                and (expr2[lh_role_uid_col] in self.gel_net.concComplUIDs
-                                     or expr2[rel_type_uid_col] in self.gel_net.concQuantUIDs
-                                     or expr2[rel_type_uid_col]
+                                and (expr2[lh_role_uid_col] in self.gel_net.concComplUIDs or
+                                     expr2[rel_type_uid_col] in self.gel_net.concQuantUIDs or
+                                     expr2[rel_type_uid_col]
                                      in self.gel_net.subConcComplRelUIDs):
                             values = [expr2[rh_uid_col], '', expr2[rel_type_uid_col],
                                       expr[rh_uid_col], expr[rh_name_col],
@@ -1058,9 +1058,9 @@ class Query_view():
                         # Find conceptual quantification (1791) value (inverse)
                         # Find conceptual compliance criterion (inverse)
                         elif role_uid == expr2[rh_uid_col] \
-                                and (expr2[rh_role_uid_col] in self.gel_net.concComplUIDs
-                                     or expr2[rel_type_uid_col] in self.gel_net.concQuantUIDs
-                                     or expr2[rel_type_uid_col]
+                                and (expr2[rh_role_uid_col] in self.gel_net.concComplUIDs or
+                                     expr2[rel_type_uid_col] in self.gel_net.concQuantUIDs or
+                                     expr2[rel_type_uid_col]
                                      in self.gel_net.subConcComplRelUIDs):
                             values = [expr2[lh_uid_col], '', expr2[rel_type_uid_col],
                                       expr[rh_uid_col], expr[rh_name_col],

--- a/Web-Communicator/QueryViews.py
+++ b/Web-Communicator/QueryViews.py
@@ -12,9 +12,9 @@ from Create_output_file import Convert_numeric_to_integer
 
 
 class MyTable(gui.Table):
-    ''' A subclass of gui.Table that has the feature
+    """ A subclass of gui.Table that has the feature
         that the last selected row is highlighted.
-    '''
+    """
     @gui.decorate_event
     def on_table_row_click(self, row, item):
         if hasattr(self, "last_clicked_row"):
@@ -25,11 +25,11 @@ class MyTable(gui.Table):
 
 
 class Query_view():
-    ''' Defines a query window
+    """ Defines a query window
         for specification of searched/queries in the semantic network
         of dictionary, knowledge and information,
         including the display of a textual definition, synonyms and translations.
-    '''
+    """
     def __init__(self, gel_net, user_interface):
         self.gel_net = gel_net
         self.user_interface = user_interface
@@ -401,7 +401,7 @@ class Query_view():
             'De antwoordtaal is {}'.format(self.user_interface.reply_lang_name))
 
     def Determine_reply_language(self, widget):
-        ''' Get the user specified reply language and report it.'''
+        """ Get the user specified reply language and report it."""
         reply_lang_name = self.reply_lang_box.get()
         self.user_interface.Set_reply_language(reply_lang_name)
         self.views.Display_message(
@@ -467,7 +467,7 @@ class Query_view():
             pass
 
     def set_case(self, widget, new_value):
-        ''' Depending on user input determine whether the search string is case sensitive'''
+        """ Depending on user input determine whether the search string is case sensitive"""
         case_sens = new_value  # self.case_sensitive_var.get()
         if case_sens:
             self.cs = 'cs'   # case sensitive
@@ -475,8 +475,8 @@ class Query_view():
             self.cs = 'ci'   # case insensitive
 
     def set_front_end(self, widget, new_value):
-        ''' Depending on user input determine whether the front end part of the found name
-            should comply with the front end part of the search string.'''
+        """ Depending on user input determine whether the front end part of the found name
+            should comply with the front end part of the search string."""
         front_end = self.front_end_match_var.get()
         if front_end:
             self.fe = 'fi'   # front end identical
@@ -691,11 +691,11 @@ class Query_view():
                 self.rh_options_tree.insert('', index='end', values=opt)
 
     def Determine_selected_aspects(self, widget, row, item):
-        ''' Determine one or more selected aspects and their values
+        """ Determine one or more selected aspects and their values
             and add them to the query.
             Note: values for the same aspects are alternative options (or)
                   values for different aspects are additional requirements (and).
-        '''
+        """
         aspect_value = []
         self.query.aspect_values = []
         for val in row.children.values():
@@ -1016,10 +1016,10 @@ class Query_view():
                         self.aliases_table_widget.append(row_widget, alias_row[1])
 
     def Determine_aspect_and_value_options(self, lh_obj_sub):
-        ''' Determine in a search the characteristics of lh_object and its subtypes
+        """ Determine in a search the characteristics of lh_object and its subtypes
             and determine the available values for those characteristics.
             These are options for conditions that reduce the selection in a query.
-        '''
+        """
         equality = '='
         for rel_obj in lh_obj_sub.relations:
             expr = rel_obj.expression
@@ -1071,9 +1071,9 @@ class Query_view():
                                 # Debug print('Values:', values)
 
     def Determine_rel_types_for_lh_object(self, lh_object):
-        ''' With given selected lh_object determine which kinds of relations are known
+        """ With given selected lh_object determine which kinds of relations are known
             and store results in self.lh_obj_relation_types
-        '''
+        """
         self.lh_obj_relation_types = []
         for lh_obj_rel in lh_object.relations:
                 expr = lh_obj_rel.expression
@@ -1094,11 +1094,11 @@ class Query_view():
                                 self.lh_obj_relation_types.append(sub_rel_type)
 
     def Determine_aliases(self, obj):
-        ''' Collect the names and translation that are known for obj
+        """ Collect the names and translation that are known for obj
             in the alias_table for display in alias_tree treeview.
             name_in_context = (lang_uid, comm_uid, name, naming_uid, description)
             alias_row = (language, term, alias_type)
-        '''
+        """
         alias_table = []
         languages = []
         for name_in_context in obj.names_in_contexts:
@@ -1338,7 +1338,7 @@ class Query_view():
         self.views.Display_notebook_views()
 
     def Close_query(self, widget, tabbox, refWidgetTab):
-        ''' Close the tab about the Search'''
+        """ Close the tab about the Search"""
         query_text = ["Search", "Zoek"]
         tabbox.select_by_widget(refWidgetTab)
         tabbox.remove_tab_by_name(query_text[self.GUI_lang_index])

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 100
-ignore = D100,D101,D102,D202,D203,D204,D205,D208,D209,D210,D300,D400,D401,E302,E731,N801,N802,N806
+ignore = D100,D101,D102,D202,D203,D204,D205,D208,D209,D210,D300,D400,D401,E302,E731,N801,N802,N803,N806
 exclude =
     # No need to traverse our git directory
     .git,

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ addopts = --flake8
 
 [flake8]
 max-line-length = 100
-ignore = D100,D101,D102,D202,D203,D204,D205,D208,D209,D210,D300,D400,D401,E302,E731,N801,N802,N803,N806
+ignore = D100,D101,D102,D202,D203,D204,D205,D208,D209,D210,D300,D400,D401,E302,E731,N801,N802,N803,N806,W504
 exclude =
     # No need to traverse our git directory
     .git,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 100
-ignore = D100,D101,D102,D202,D203,D204,D205,D208,D209,D210,D300,D400,E302,E731,N801,N802,N806
+ignore = D100,D101,D102,D202,D203,D204,D205,D208,D209,D210,D300,D400,D401,E302,E731,N801,N802,N806
 exclude =
     # No need to traverse our git directory
     .git,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 100
-ignore = D100,D101,D102,D202,D203,D204,D205,D208,D210,D300,D400,E302,E731,N801,N802,N806
+ignore = D100,D101,D102,D202,D203,D204,D205,D208,D209,D210,D300,D400,E302,E731,N801,N802,N806
 exclude =
     # No need to traverse our git directory
     .git,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[tool:pytest]
+addopts = --flake8
+
 [flake8]
 max-line-length = 100
 ignore = D100,D101,D102,D202,D203,D204,D205,D208,D209,D210,D300,D400,D401,E302,E731,N801,N802,N803,N806


### PR DESCRIPTION
The "line break before binary operator" errors are fixed, but they reveal an overcomplicated flow.

Example: In `Display_views.py`, the statements
```python
                    if (column_nr == 1 and (
                            field_value in self.comp_head or
                            field_value in self.occ_head or
                            field_value in self.info_head)) \
                            or column_nr == 2 and field_value in self.part_occ_head:
                        # Header line detected; set background color accordingly
                        head = True
                        back = '#dfb'

```
could be replaced by something like:
```python
                    if column_nr == 1:
                        if field_value in self.comp_head + self.occ_head + self.info_head:
                            set_header_background()
                    if column_nr == 2 and field_value in self.part_occ_head:
                        set_header_background()
                    def set_header_background()
                        """Header line detected; set background color accordingly"""
                        head = True
                        back = '#dfb'

```

Side note: It's not always necessary to use brackets, see the "Operator precedence" paragraph on  
https://docs.python.org/3/reference/expressions.html. 

In addition, having Travis `script` run `make test` caused python2 to be used, which led to "undefined names" because names are standard in python3 but not python2. We now make Travis `script` run `pytest` directly.